### PR TITLE
Call input functions with namespaces

### DIFF
--- a/R/available_inputs.R
+++ b/R/available_inputs.R
@@ -8,5 +8,19 @@ load_available_inputs <- function(){
   yaml::read_yaml(system.file("available_inputs.yaml", package = "parmesan"))
 }
 
+lookup_input_namespace <- function(){
+  inputs <- load_available_inputs()
+  inputs_packages <- data.frame(names = names(unlist(load_available_inputs(), recursive = FALSE))) %>%
+    tidyr::separate(names, c("package", "input")) %>%
+    dplyr::mutate(ns = paste0(package, "::", input))
+  inputs_lookup <- inputs_packages %>% dplyr::pull(ns)
+  names(inputs_lookup) <- inputs_packages %>% dplyr::pull(input)
+  inputs_lookup
+}
+
+input_namespace <- function(input){
+  as.character(lookup_input_namespace()[input])
+}
+
 
 

--- a/R/render_par_input.R
+++ b/R/render_par_input.R
@@ -107,12 +107,16 @@ validate_show_if <- function(par_input, input, env, debug = FALSE){
 
 
 render_par_html <- function(par_input) {
+
+  inputtype <- par_input$input_type
+  input_type_with_ns <- input_namespace(inputtype)
+
   par_input$input_params$inputId <- par_input$id
   if (!is.null(par_input$input_info)) {
     par_input$input_params$label <- parmesan:::infoTooltip(par_input)
-    return(do.call(par_input$input_type, par_input$input_params))
+    return(do.call(getfun(input_type_with_ns), par_input$input_params))
   }
-  return(do.call(par_input$input_type, par_input$input_params))
+  return(do.call(getfun(input_type_with_ns), par_input$input_params))
 }
 
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -15,3 +15,14 @@ is.empty <- function (x)
 {
   !as.logical(length(x))
 }
+
+
+#' Get function from string of namespace::function() to pass to do.call
+getfun <- function(x) {
+  if(length(grep("::", x))>0) {
+    parts <- strsplit(x, "::")[[1]]
+    getExportedValue(parts[1], parts[2])
+  } else {
+    x
+  }
+}

--- a/tests/testthat/test-render.R
+++ b/tests/testthat/test-render.R
@@ -105,6 +105,12 @@ test_that("info tooltip works", {
 })
 
 
+test_that("namespace lookup works", {
 
+  expect_equal(input_namespace("colorPaletteInput"), "shinyinvoer::colorPaletteInput")
+
+  expect_equal(input_namespace("actionButton"), "shiny::actionButton")
+
+})
 
 


### PR DESCRIPTION
The `render_par_html` function now includes the package namespaces in when calling the input functions in `do.call`. 