### PR TITLE
Make work within module

### DIFF
--- a/R/available_inputs.R
+++ b/R/available_inputs.R
@@ -18,9 +18,21 @@ lookup_input_namespace <- function(){
   inputs_lookup
 }
 
+lookup_updateInput_namespace <- function(){
+  inputs <- load_available_inputs()
+  inputs_packages <- data.frame(names = names(unlist(load_available_inputs(), recursive = FALSE))) %>%
+    tidyr::separate(names, c("package", "input")) %>%
+    dplyr::mutate(ns = paste0(package, "::update", firstup(input)))
+  inputs_lookup <- inputs_packages %>% dplyr::pull(ns)
+  names(inputs_lookup) <- inputs_packages %>% dplyr::pull(input)
+  inputs_lookup
+}
+
 input_namespace <- function(input){
   as.character(lookup_input_namespace()[input])
 }
 
-
+updateInput_namespace <- function(input){
+  as.character(lookup_updateInput_namespace()[input])
+}
 

--- a/R/output.R
+++ b/R/output.R
@@ -1,11 +1,17 @@
 
 #' @export
-output_parmesan <- function(id, parmesan = NULL,
-                            input = input, output = output,
-                            session = session,
+output_parmesan <- function(id,
+                            r = NULL,
+                            parmesan = NULL,
                             container_section = NULL,
+                            parent = getDefaultReactiveDomain(),
                             env = parent.frame(),
-                            panic = FALSE, debug = FALSE){
+                            panic = FALSE,
+                            debug = FALSE){
+
+  moduleServer(id, function(input, output, session){
+    ns <- parent$ns
+
   if(is.null(parmesan)){
     parmesan <- parmesan_load()
   }
@@ -24,8 +30,8 @@ output_parmesan <- function(id, parmesan = NULL,
     #insert section placeholders
     lapply(sections, function(section){
       removeUI(selector = paste0("#section-",section), immediate = TRUE)
-      insertUI(paste0("#",id), immediate = TRUE,
-               ui = div(class = "section_0", id = paste0("section-",section)),)
+      insertUI(paste0("#",ns(id)), immediate = TRUE,
+               ui = div(class = "section_0", id = paste0("section-",section)))
     })
 
     # Insert sections titles and boxes leaving out inputs.
@@ -37,6 +43,7 @@ output_parmesan <- function(id, parmesan = NULL,
                                    render_inputs = FALSE,
                                    env = env))
     })
+
 
     # Do we first need to insert individual inputs
     # with no dependencies in each section? Not for now.
@@ -53,26 +60,26 @@ output_parmesan <- function(id, parmesan = NULL,
     # })
 
 
-
     # Second insert all inputs with dependencies
     # Create outputs for all inputs
     # (only those with dependencies?, not for now)
 
-    lapply(parmesan, function(section){
-      lapply(section$inputs, function(par_input){
-        # if(input_has_dependencies(par_input)){
-        output[[paste0("output_",par_input$id)]] <- renderUI({
-          render_par_input(par_input, input = input, env = env, debug = debug)
-        })
-        # }
-      })
-    })
+    # lapply(parmesan, function(section){
+    #   lapply(section$inputs, function(par_input){
+    #     # if(input_has_dependencies(par_input)){
+    #     output[[paste0("output_",par_input$id)]] <- renderUI({
+    #       # render_par_input(par_input = par_input, input = input, env = env, debug = debug)
+    #       selectInput(par_input$id, label = "blahblah", choices = c("rock", "pressure"))
+    #     })
+    #     # }
+    #   })
+    # })
     # Create UIs for all inputs with dependencies
     lapply(parmesan, function(section){
       lapply(section$inputs, function(par_input){
         # if(input_has_dependencies(par_input)){
         insertUI(paste0("#",section$id), immediate = TRUE,
-                 ui = uiOutput(paste0("output_",par_input$id)))
+                 ui = div(render_par_input(par_input = par_input, input = input, env = env, debug = debug, parent = parent, r = r)))
         # }
       })
     })
@@ -83,6 +90,7 @@ output_parmesan <- function(id, parmesan = NULL,
       shiny::tags$script("Shiny.onInputChange('parmesan_updated',+new Date);")
     })
 
+  })
 
   })
 

--- a/R/output.R
+++ b/R/output.R
@@ -16,7 +16,7 @@ output_parmesan <- function(id,
     parmesan <- parmesan_load()
   }
 
-  # Insert sections and inputs
+  # Initialise sections and inputs (insert all without reactives or conditions)
   observe({
     if(shiny::is.reactive(parmesan))
       parmesan <- parmesan()

--- a/R/output.R
+++ b/R/output.R
@@ -86,7 +86,8 @@ output_parmesan <- function(id,
         if(!input_has_show_if(par_input)){
           insertUI(paste0("#",section$id),
                    immediate = TRUE,
-                   ui = div(render_par_input(par_input = par_input, input = input, env = env, debug = debug, parent = parent, r = r)))
+                   ui = div(id = paste0("output_",par_input$id),
+                            render_par_input(par_input = par_input, input = input, env = env, debug = debug, parent = parent, r = r)))
         }
 
       })
@@ -133,11 +134,12 @@ output_parmesan <- function(id,
             conditions_passed <- validate_show_if(par_input = par_input, input = input, env = env, parent = parent, r = r, debug = debug)
 
             last_input <- section$inputs[[x-1]]
-            last_input_id <- last_input$id
-            last_input_id_with_ns <- paste0("#",ns(last_input_id))
+            last_input_id <- paste0("output_", last_input$id)
+            last_input_id_div <- paste0("#",last_input_id)
 
             if(conditions_passed){
-              insertUI(last_input_id_with_ns,
+              insertUI(last_input_id_div,
+                       where = "afterEnd",
                        immediate = TRUE,
                        ui = div(id = paste0("output_",par_input$id),
                                 render_par_html(par_input = par_input, parent = parent)))

--- a/R/output.R
+++ b/R/output.R
@@ -2,21 +2,22 @@
 #' @export
 output_parmesan <- function(id,
                             r = NULL,
-                            parmesan = NULL,
-                            container_section = NULL,
                             parent = NULL,
+                            parmesan = NULL,
+                            input = input,
+                            output = output,
+                            session = session,
+                            container_section = NULL,
                             env = parent.frame(),
-                            panic = FALSE,
-                            debug = FALSE){
+                            panic = FALSE, debug = FALSE){
 
-  moduleServer(id, function(input, output, session){
-    ns <- parent$ns
+  ns <- parent$ns
 
   if(is.null(parmesan)){
     parmesan <- parmesan_load()
   }
 
-  # observe({
+  observe({
     if(shiny::is.reactive(parmesan))
       parmesan <- parmesan()
 
@@ -48,36 +49,7 @@ output_parmesan <- function(id,
                                    env = env))
     })
 
-
-    # Do we first need to insert individual inputs
-    # with no dependencies in each section? Not for now.
-
-    # # First insert all inputs with no dependencies
-    # lapply(parmesan, function(section){
-    #   lapply(section$inputs, function(par_input){
-    #     if(!input_has_dependencies(par_input)){
-    #       insertUI(paste0("#section-",section$id),
-    #                ui = render_par_input(par_input, input = input, env = env)
-    #       )
-    #     }
-    #   })
-    # })
-
-
-    # Second insert all inputs with dependencies
-    # Create outputs for all inputs
-    # (only those with dependencies?, not for now)
-
-    # lapply(parmesan, function(section){
-    #   lapply(section$inputs, function(par_input){
-    #     # if(input_has_dependencies(par_input)){
-    #     output[[paste0("output_",par_input$id)]] <- renderUI({
-    #       # render_par_input(par_input = par_input, input = input, env = env, debug = debug)
-    #       selectInput(par_input$id, label = "blahblah", choices = c("rock", "pressure"))
-    #     })
-    #     # }
-    #   })
-    # })
+    # Second insert all inputs
 
     # Create UIs for all inputs without conditionals
     lapply(parmesan, function(section){
@@ -93,7 +65,12 @@ output_parmesan <- function(id,
       })
     })
 
+  })
+
     observe({
+      if(shiny::is.reactive(parmesan))
+        parmesan <- parmesan()
+
       lapply(parmesan, function(section){
         lapply(section$inputs, function(par_input){
           # Update inputs that have reactive values
@@ -125,6 +102,9 @@ output_parmesan <- function(id,
     })
 
     observe({
+      if(shiny::is.reactive(parmesan))
+        parmesan <- parmesan()
+
       lapply(parmesan, function(section){
         lapply(seq_along(section$inputs), function(x){
           par_input <- section$inputs[[x]]
@@ -138,6 +118,7 @@ output_parmesan <- function(id,
             last_input_id_div <- paste0("#",last_input_id)
 
             if(conditions_passed){
+              removeUI(selector = paste0("#output_",par_input$id), immediate = TRUE)
               insertUI(last_input_id_div,
                        where = "afterEnd",
                        immediate = TRUE,
@@ -159,9 +140,8 @@ output_parmesan <- function(id,
       shiny::tags$script("Shiny.onInputChange('parmesan_updated',+new Date);")
     })
 
-  })
-
   # })
+
 
 }
 

--- a/R/output.R
+++ b/R/output.R
@@ -4,7 +4,7 @@ output_parmesan <- function(id,
                             r = NULL,
                             parmesan = NULL,
                             container_section = NULL,
-                            parent = getDefaultReactiveDomain(),
+                            parent = NULL,
                             env = parent.frame(),
                             panic = FALSE,
                             debug = FALSE){
@@ -30,7 +30,11 @@ output_parmesan <- function(id,
     #insert section placeholders
     lapply(sections, function(section){
       removeUI(selector = paste0("#section-",section), immediate = TRUE)
-      insertUI(paste0("#",ns(id)), immediate = TRUE,
+      section_id <- id
+      if(!is.null(parent)){
+        section_id <- ns(id)
+      }
+      insertUI(paste0("#",section_id), immediate = TRUE,
                ui = div(class = "section_0", id = paste0("section-",section)))
     })
 

--- a/R/output.R
+++ b/R/output.R
@@ -53,7 +53,7 @@ output_parmesan <- function(id,
           insertUI(paste0("#",section$id),
                    immediate = TRUE,
                    ui = div(id = paste0("output_",par_input$id),
-                            render_par_input(par_input = par_input, input = input, env = env, debug = debug, parent = session, r = r)))
+                            render_par_input(par_input = par_input, parent = session)))
         }
 
       })
@@ -127,7 +127,7 @@ output_parmesan <- function(id,
                      where = "afterEnd",
                      immediate = TRUE,
                      ui = div(id = paste0("output_",par_input$id),
-                              render_par_html(par_input = par_input, parent = session)))
+                              render_par_input(par_input = par_input, parent = session)))
           } else {
             removeUI(selector = paste0("#output_",par_input$id), immediate = TRUE)
           }
@@ -165,7 +165,7 @@ output_parmesan <- function(id,
                    where = "afterEnd",
                    immediate = TRUE,
                    ui = div(id = paste0("output_",par_input$id),
-                            render_par_html(par_input = par_input, parent = session)))
+                            render_par_input(par_input = par_input, parent = session)))
         }
       })
     })

--- a/R/render_par_input.R
+++ b/R/render_par_input.R
@@ -1,32 +1,12 @@
-render_par_input <- function(par_input, input,
-                             env = parent.frame(),
-                             debug = FALSE,
+render_par_input <- function(par_input,
                              parent = NULL,
-                             r = NULL){
+                             debug = FALSE){
 
   if(!par_input$show) return()
 
-  # # Replace any reactives tooltip
-  # if(input_has_reactive_tooltip_text(par_input)){
-  #   message("\n\nHAS REACTIVE TOOLTIP")
-  #   str(par_input)
-  #   #par_input <- replace_reactive_param_values(par_input, env = env)
-  #   str(replace_reactive_tooltip_text(par_input, env = env))
-  #   par_input <- replace_reactive_tooltip_text(par_input, env = env)
-  # }
-
-    html <- render_par_html(par_input, parent)
-    return(html)
-
+  html <- render_par_html(par_input = par_input, parent = parent)
+  return(html)
 }
-
-replace_reactive_tooltip_text <- function(par_input, env = parent.frame()){
-  text <-  par_input$input_info$text
-  text <- do.call(remove_parenthesis(text), list(), envir = env)
-  par_input$input_info$text <- text
-  par_input
-}
-
 
 
 validate_show_if <- function(par_input, input, env, parent, r, debug = FALSE){

--- a/R/render_par_input.R
+++ b/R/render_par_input.R
@@ -3,23 +3,17 @@ render_par_input <- function(par_input, input,
                              debug = FALSE,
                              parent = NULL,
                              r = NULL){
-  # message("\nRendering input: ", par_input$id, "\n")
 
   if(!par_input$show) return()
 
-  # Replace any reactives in param values
-  if(input_has_reactive_param_values(par_input)){
-    par_input <- replace_reactive_param_values(par_input, env = env, parent = parent, r = r)
-  }
-
-  # Replace any reactives tooltip
-  if(input_has_reactive_tooltip_text(par_input)){
-    message("\n\nHAS REACTIVE TOOLTIP")
-    str(par_input)
-    #par_input <- replace_reactive_param_values(par_input, env = env)
-    str(replace_reactive_tooltip_text(par_input, env = env))
-    par_input <- replace_reactive_tooltip_text(par_input, env = env)
-  }
+  # # Replace any reactives tooltip
+  # if(input_has_reactive_tooltip_text(par_input)){
+  #   message("\n\nHAS REACTIVE TOOLTIP")
+  #   str(par_input)
+  #   #par_input <- replace_reactive_param_values(par_input, env = env)
+  #   str(replace_reactive_tooltip_text(par_input, env = env))
+  #   par_input <- replace_reactive_tooltip_text(par_input, env = env)
+  # }
 
   # Has no conditionals
   if (!input_has_show_if(par_input)) {
@@ -38,25 +32,6 @@ render_par_input <- function(par_input, input,
 
 }
 
-replace_reactive_param_values <- function(par_input, env = parent.frame(), parent = NULL, r = NULL){
-  params <-  par_input$input_params
-  pars <- names(Filter(function(x) grepl("\\(\\)", x), params))
-
-  params_reactive <- lapply(pars, function(par){
-    inp <- par_input$input_params[[par]]
-    if(is.null(parent)){
-      dep_value_params <- do.call(remove_parenthesis(inp), list(), envir = env)
-    } else {
-      dep_value_params <- do.call(r[[remove_parenthesis(inp)]], list())
-    }
-    dep_value_params
-  })
-  names(params_reactive) <- pars
-  params <- modifyList(params, params_reactive, keep.null = TRUE)
-  par_input$input_params <- params
-  par_input
-}
-
 replace_reactive_tooltip_text <- function(par_input, env = parent.frame()){
   text <-  par_input$input_info$text
   text <- do.call(remove_parenthesis(text), list(), envir = env)
@@ -73,7 +48,7 @@ validate_show_if <- function(par_input, input, env, parent, r, debug = FALSE){
 
   if(debug) message("\nRendering: ", par_input$id)
   condition_type <- names(par_input)[grep("show_",names(par_input))]
-# browser()
+
   conditions <- lapply(seq_along(par_input$show_if), function(i){
     condition <- names(par_input$show_if[[i]])
     value1 <- names(par_input$show_if)[[i]]
@@ -140,9 +115,8 @@ render_par_html <- function(par_input, parent = NULL) {
     par_input_id <- ns(par_input$id)
   }
 
-
-  inputtype <- par_input$input_type
-  input_type_with_ns <- input_namespace(inputtype)
+  input_type <- par_input$input_type
+  input_type_with_ns <- input_namespace(input_type)
 
   par_input$input_params$inputId <- par_input_id
   if (!is.null(par_input$input_info)) {

--- a/R/render_par_input.R
+++ b/R/render_par_input.R
@@ -15,20 +15,8 @@ render_par_input <- function(par_input, input,
   #   par_input <- replace_reactive_tooltip_text(par_input, env = env)
   # }
 
-  # Has no conditionals
-  if (!input_has_show_if(par_input)) {
     html <- render_par_html(par_input, parent)
     return(html)
-  }
-  # Show if dependency
-  if(input_has_show_if(par_input)){
-    if(is.null(input)) stop("Need to pass input to render_section")
-    if(validate_show_if(par_input = par_input, input = input, env = env, parent = parent, r = r, debug = debug)){
-      html <- render_par_html(par_input, parent)
-      #html <- render_par_html(par_input, env = env, debug = debug)
-      return(html)
-    }
-  }
 
 }
 
@@ -104,7 +92,6 @@ validate_show_if <- function(par_input, input, env, parent, r, debug = FALSE){
   if(condition_type == "show_if_any")
     return(any(pass_conditions))
 }
-
 
 
 render_par_html <- function(par_input, parent = NULL) {

--- a/R/render_par_input.R
+++ b/R/render_par_input.R
@@ -9,7 +9,7 @@ render_par_input <- function(par_input, input,
 
   # Replace any reactives in param values
   if(input_has_reactive_param_values(par_input)){
-    par_input <- replace_reactive_param_values(par_input, env = env, r = r)
+    par_input <- replace_reactive_param_values(par_input, env = env, parent = parent, r = r)
   }
 
   # Replace any reactives tooltip
@@ -28,10 +28,9 @@ render_par_input <- function(par_input, input,
   }
   # Show if dependency
   if(input_has_show_if(par_input)){
-    # browser()
     if(is.null(input)) stop("Need to pass input to render_section")
     if(validate_show_if(par_input = par_input, input = input, env = env, parent = parent, r = r, debug = debug)){
-      html <- render_par_html(par_input)
+      html <- render_par_html(par_input, parent)
       #html <- render_par_html(par_input, env = env, debug = debug)
       return(html)
     }
@@ -39,13 +38,13 @@ render_par_input <- function(par_input, input,
 
 }
 
-replace_reactive_param_values <- function(par_input, env = parent.frame(), r = NULL){
+replace_reactive_param_values <- function(par_input, env = parent.frame(), parent = NULL, r = NULL){
   params <-  par_input$input_params
   pars <- names(Filter(function(x) grepl("\\(\\)", x), params))
 
   params_reactive <- lapply(pars, function(par){
     inp <- par_input$input_params[[par]]
-    if(is.null(r)){
+    if(is.null(parent)){
       dep_value_params <- do.call(remove_parenthesis(inp), list(), envir = env)
     } else {
       dep_value_params <- do.call(r[[remove_parenthesis(inp)]], list())
@@ -74,7 +73,7 @@ validate_show_if <- function(par_input, input, env, parent, r, debug = FALSE){
 
   if(debug) message("\nRendering: ", par_input$id)
   condition_type <- names(par_input)[grep("show_",names(par_input))]
-
+# browser()
   conditions <- lapply(seq_along(par_input$show_if), function(i){
     condition <- names(par_input$show_if[[i]])
     value1 <- names(par_input$show_if)[[i]]
@@ -84,7 +83,7 @@ validate_show_if <- function(par_input, input, env, parent, r, debug = FALSE){
     if(is_shiny_input(x = value1, input = input, r = r)){
       value1ini <- value1
 
-      if(is.null(parent)){
+      if(is.null(r)){
         value1 <- input[[value1]]
       } else {
         value1 <- r[[value1]]
@@ -93,7 +92,7 @@ validate_show_if <- function(par_input, input, env, parent, r, debug = FALSE){
     }
     if(is_reactive_string(value1)){
       value1ini <- value1
-      if(is.null(parent)){
+      if(is.null(r)){
         value1 <- do.call(remove_parenthesis(value1), list(), envir = env)
       } else {
         value1 <- do.call(r[[remove_parenthesis(inp)]], list())
@@ -102,7 +101,7 @@ validate_show_if <- function(par_input, input, env, parent, r, debug = FALSE){
     if(is_shiny_input(x = value2, input = input, r = r)){
       value2ini <- value2
 
-      if(is.null(parent)){
+      if(is.null(r)){
         value2 <- input[[value2]]
       } else {
         value2 <- r[[value2]]

--- a/R/render_par_input.R
+++ b/R/render_par_input.R
@@ -30,7 +30,7 @@ render_par_input <- function(par_input, input,
   if(input_has_show_if(par_input)){
     # browser()
     if(is.null(input)) stop("Need to pass input to render_section")
-    if(validate_show_if(par_input, input, env, parent, debug = debug)){
+    if(validate_show_if(par_input = par_input, input = input, env = env, parent = parent, r = r, debug = debug)){
       html <- render_par_html(par_input)
       #html <- render_par_html(par_input, env = env, debug = debug)
       return(html)
@@ -67,7 +67,7 @@ replace_reactive_tooltip_text <- function(par_input, env = parent.frame()){
 
 
 
-validate_show_if <- function(par_input, input, env, parent, debug = FALSE){
+validate_show_if <- function(par_input, input, env, parent, r, debug = FALSE){
   if(is.null(par_input)) return()
 
   ns <- parent$ns
@@ -79,22 +79,34 @@ validate_show_if <- function(par_input, input, env, parent, debug = FALSE){
     condition <- names(par_input$show_if[[i]])
     value1 <- names(par_input$show_if)[[i]]
     value2 <- par_input$show_if[[i]][[1]]
+
     value2ini <- value1ini <- NULL
-    if(is_shiny_input(value1, input)){
+    if(is_shiny_input(x = value1, input = input, r = r)){
       value1ini <- value1
-      value1 <- input[[value1]]
-    }
-    if(is_shiny_input(value1, input)){
-      value1ini <- value1
-      value1 <- input[[value1]]
+
+      if(is.null(parent)){
+        value1 <- input[[value1]]
+      } else {
+        value1 <- r[[value1]]
+      }
+
     }
     if(is_reactive_string(value1)){
       value1ini <- value1
-      value1 <- do.call(remove_parenthesis(value1), list(), envir = env)
+      if(is.null(parent)){
+        value1 <- do.call(remove_parenthesis(value1), list(), envir = env)
+      } else {
+        value1 <- do.call(r[[remove_parenthesis(inp)]], list())
+      }
     }
-    if(is_shiny_input(value2, input)){
+    if(is_shiny_input(x = value2, input = input, r = r)){
       value2ini <- value2
-      value2 <- input[[value2]]
+
+      if(is.null(parent)){
+        value2 <- input[[value2]]
+      } else {
+        value2 <- r[[value2]]
+      }
     }
     if(is_reactive_string(value1)){
       value2ini <- value2

--- a/R/render_par_input_helpers.R
+++ b/R/render_par_input_helpers.R
@@ -36,7 +36,7 @@ is_shiny_input <- function(x, input, r = NULL){
   if(!is.null(r)){
     validate <- !is.null(r[[x]])
   }
-
+ validate
 }
 
 

--- a/R/render_par_input_helpers.R
+++ b/R/render_par_input_helpers.R
@@ -25,14 +25,18 @@ is_reactive_string <- function(x){
   any(grepl("\\(\\)", x))
 }
 
-is_shiny_input <- function(x, input){
+is_shiny_input <- function(x, input, r = NULL){
   if(shiny::is.reactive(x)) return(FALSE)
   if(!is.character(x)) return(FALSE)
   # For multiple values in conditional inputs
   # Doesn't work yet when conditionals are vectors or reactives
   if(length(x) > 1) return(FALSE)
 
-  !is.null(input[[x]])
+  validate <- !is.null(input[[x]])
+  if(!is.null(r)){
+    validate <- !is.null(r[[x]])
+  }
+
 }
 
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -27,3 +27,8 @@ getfun <- function(x) {
     x
   }
 }
+
+firstup <- function(x) {
+  substr(x, 1, 1) <- toupper(substr(x, 1, 1))
+  x
+}

--- a/inst/examples/ex07-reactive-output-shi18ny/app.R
+++ b/inst/examples/ex07-reactive-output-shi18ny/app.R
@@ -49,19 +49,22 @@ server <-  function(input, output, session) {
   })
 
   output_parmesan("all_controls_here", parmesan = parmesan_lang,
-                  input = input, output = output, session = session,
-                  env = environment())
+                  # input = input, output = output, session = session,
+                  env = environment(), parent = session)
   # output_parmesan("all_controls_here", parmesan = parmesan,
 
+
   output$debug <- renderPrint({
-    paste0(
-      "Parmesan updated: ", input$parmesan_updated
-      # str(parmesan_input())
-      )
+    # paste0(
+    #   "Parmesan updated: ", input$parmesan_updated
+    #   # str(parmesan_input())
+    #   )
+    str(parmesan_input())
   })
 
   datasetInput <- reactive({
     req(input$dataset)
+    # browser()
     get(input$dataset)
   })
 

--- a/inst/examples/ex07-reactive-output-shi18ny/app.R
+++ b/inst/examples/ex07-reactive-output-shi18ny/app.R
@@ -48,23 +48,10 @@ server <-  function(input, output, session) {
     i_(parmesan, lang(), keys = c("label", "choices"))
   })
 
-  output_parmesan("all_controls_here", parmesan = parmesan_lang,
-                  # input = input, output = output, session = session,
-                  env = environment())
-  # output_parmesan("all_controls_here", parmesan = parmesan,
-
-
-  output$debug <- renderPrint({
-    # paste0(
-    #   "Parmesan updated: ", input$parmesan_updated
-    #   # str(parmesan_input())
-    #   )
-    str(parmesan_input())
-  })
+  r <- reactiveValues()
 
   datasetInput <- reactive({
     req(input$dataset)
-    # browser()
     get(input$dataset)
   })
 
@@ -75,6 +62,24 @@ server <-  function(input, output, session) {
 
   datasetNColsLabel <- reactive({
     paste0("Colums (max = ", datasetNCols(),")")
+  })
+
+  observe({
+    r$plot_type <- input$plot_type
+  })
+
+  output_parmesan("all_controls_here", parmesan = parmesan_lang,
+                  # input = input, output = output, session = session,
+                  env = environment(), r = r)
+  # output_parmesan("all_controls_here", parmesan = parmesan,
+
+
+  output$debug <- renderPrint({
+    # paste0(
+    #   "Parmesan updated: ", input$parmesan_updated
+    #   # str(parmesan_input())
+    #   )
+    str(parmesan_input())
   })
 
 

--- a/inst/examples/ex07-reactive-output-shi18ny/app.R
+++ b/inst/examples/ex07-reactive-output-shi18ny/app.R
@@ -50,7 +50,7 @@ server <-  function(input, output, session) {
 
   output_parmesan("all_controls_here", parmesan = parmesan_lang,
                   # input = input, output = output, session = session,
-                  env = environment(), parent = session)
+                  env = environment())
   # output_parmesan("all_controls_here", parmesan = parmesan,
 
 

--- a/inst/examples/ex07-reactive-output-shi18ny/app.R
+++ b/inst/examples/ex07-reactive-output-shi18ny/app.R
@@ -64,13 +64,9 @@ server <-  function(input, output, session) {
     paste0("Colums (max = ", datasetNCols(),")")
   })
 
-  observe({
-    r$plot_type <- input$plot_type
-  })
-
   output_parmesan("all_controls_here", parmesan = parmesan_lang,
-                  # input = input, output = output, session = session,
-                  env = environment(), r = r)
+                  input = input, output = output, session = session,
+                  env = environment())
   # output_parmesan("all_controls_here", parmesan = parmesan,
 
 

--- a/inst/examples/ex08-info-tooltips/app.R
+++ b/inst/examples/ex08-info-tooltips/app.R
@@ -12,9 +12,13 @@ server <-  function(input, output, session) {
   path <- system.file("examples", "ex08-info-tooltips", "parmesan", package = "parmesan")
   parmesan <- parmesan_load(path)
 
-  output$controls_container <- renderUI({
-    render_section(parmesan = parmesan)
-  })
+  # output$controls_container <- renderUI({
+  #   render_section(parmesan = parmesan)
+  # })
+
+  output_parmesan("controls_container", parmesan = parmesan,
+                  input = input, output = output, session = session,
+                  env = environment())
 
   custom_bins_text <- reactive({
     input$new_tooltip

--- a/inst/examples/ex10-within-module/app.R
+++ b/inst/examples/ex10-within-module/app.R
@@ -33,6 +33,14 @@ parmServer <- function(id, r) {
         r$datasetNCols <- datasetNCols
       })
 
+      observe({
+        r$datasetInput <- datasetInput()
+        r$dataset <- input$dataset
+        r$column <- input$column
+        r$plot_type <- input$plot_type
+        r$bins <- input$bins
+      })
+
 
       path <- system.file("examples", "ex05-reactive-output", "parmesan",
                           package = "parmesan")
@@ -54,13 +62,7 @@ parmServer <- function(id, r) {
         "hello"
       })
 
-      observe({
-        r$datasetInput <- datasetInput()
-        r$dataset <- input$dataset
-        r$column <- input$column
-        r$plot_type <- input$plot_type
-        r$bins <- input$bins
-      })
+
 
 
     }

--- a/inst/examples/ex10-within-module/app.R
+++ b/inst/examples/ex10-within-module/app.R
@@ -51,7 +51,8 @@ parmServer <- function(id, r) {
         parmesan_alert(parmesan, env = environment())
 
         output_parmesan("all_controls_here", r = r, parmesan = parmesan,
-                        container_section = div_dark, parent = session)
+                        input = input, output = output, session = session,
+                        container_section = div_dark)
 
 
       output$debug <- renderPrint({

--- a/inst/examples/ex10-within-module/app.R
+++ b/inst/examples/ex10-within-module/app.R
@@ -58,8 +58,7 @@ parmServer <- function(id, r) {
 
 
       output$debug <- renderPrint({
-        # str(parmesan_input())
-        "hello"
+        str(parmesan_input())
       })
 
 
@@ -70,8 +69,8 @@ parmServer <- function(id, r) {
 }
 
 ui <- fluidPage(
-  titlePanel("Example 05 - Hello Parmesan!"),
-  h3("Children input elements do not need to be rendered as independent outputs."),
+  titlePanel("Example 10 - Hello Parmesan!"),
+  h3("Use parmesan inputs from within a shiny module."),
   column(4,
          parmUI("parm_module")
   ),

--- a/inst/examples/ex10-within-module/app.R
+++ b/inst/examples/ex10-within-module/app.R
@@ -1,0 +1,116 @@
+library(shiny)
+library(parmesan)
+
+parmUI <- function(id) {
+  ns <- NS(id)
+  tagList(
+    uiOutput(ns("all_controls_here")),
+    verbatimTextOutput(ns("debug"))
+  )
+}
+
+parmServer <- function(id, r) {
+  moduleServer(
+    id,
+    function(input, output, session) {
+
+      datasetInput <- reactive({
+        req(input$dataset)
+        get(input$dataset)
+      })
+
+      datasetNCols <- reactive({
+        req(datasetInput())
+        ncol(datasetInput())
+      })
+
+      datasetNColsLabel <- reactive({
+        paste0("Colums (max = ", datasetNCols(),")")
+      })
+
+      observe({
+        r$datasetNColsLabel <- datasetNColsLabel
+        r$datasetNCols <- datasetNCols
+      })
+
+
+      path <- system.file("examples", "ex05-reactive-output", "parmesan",
+                          package = "parmesan")
+
+        parmesan <- parmesan_load(path)
+
+        # Put all parmesan inputs in reactive values
+
+        parmesan_input <- parmesan_watch(input, parmesan)
+
+        parmesan_alert(parmesan, env = environment())
+
+        output_parmesan("all_controls_here", r = r, parmesan = parmesan,
+                        container_section = div_dark, parent = session)
+
+
+      output$debug <- renderPrint({
+        # str(parmesan_input())
+        "hello"
+      })
+
+      observe({
+        r$datasetInput <- datasetInput()
+        r$dataset <- input$dataset
+        r$column <- input$column
+        r$plot_type <- input$plot_type
+        r$bins <- input$bins
+      })
+
+
+    }
+  )
+}
+
+ui <- fluidPage(
+  titlePanel("Example 05 - Hello Parmesan!"),
+  h3("Children input elements do not need to be rendered as independent outputs."),
+  column(4,
+         parmUI("parm_module")
+  ),
+  column(8,
+         plotOutput("distPlot")
+  )
+)
+
+div_dark <- function(...){
+  div(style="background-color:#f4f4f7;border: 1px solid #CCC;border-radius:10px;padding:10px;margin-bottom:10px;", ...)
+}
+
+server <-  function(input, output, session) {
+
+  r <- reactiveValues()
+
+  parmServer("parm_module", r = r)
+
+  output$distPlot <- renderPlot({
+    req(r$dataset, r$column, r$datasetInput)
+    dataset  <- r$dataset
+    column <- r$column
+    x <- r$datasetInput[, column]
+    column_name <- names(r$datasetInput)[column]
+
+    # browser()
+
+    if(r$plot_type == "Plot"){
+      plot <- plot(x)
+    }
+    if(r$plot_type == "Histogram"){
+      req(r$bins)
+      bins <- seq(min(x), max(x), length.out = r$bins + 1)
+      plot <- hist(x, breaks = bins, col = "#75AADB", border = "white",
+                   xlab = paste0("Values of ", column_name),
+                   main =  paste0("This is ", dataset, ", column ", column))
+    }
+    plot
+  })
+
+}
+
+
+shinyApp(ui, server)

--- a/inst/examples/ex10-within-module/app.R
+++ b/inst/examples/ex10-within-module/app.R
@@ -31,9 +31,6 @@ parmServer <- function(id, r) {
       observe({
         r$datasetNColsLabel <- datasetNColsLabel
         r$datasetNCols <- datasetNCols
-      })
-
-      observe({
         r$datasetInput <- datasetInput()
         r$dataset <- input$dataset
         r$column <- input$column
@@ -42,7 +39,7 @@ parmServer <- function(id, r) {
       })
 
 
-      path <- system.file("examples", "ex05-reactive-output", "parmesan",
+      path <- system.file("examples", "ex10-within-module", "parmesan",
                           package = "parmesan")
 
         parmesan <- parmesan_load(path)
@@ -91,12 +88,12 @@ server <-  function(input, output, session) {
 
   output$distPlot <- renderPlot({
     req(r$dataset, r$column, r$datasetInput)
+    # req(r$dataset, r$datasetInput)
     dataset  <- r$dataset
     column <- r$column
     x <- r$datasetInput[, column]
     column_name <- names(r$datasetInput)[column]
 
-    # browser()
 
     if(r$plot_type == "Plot"){
       plot <- plot(x)
@@ -107,6 +104,7 @@ server <-  function(input, output, session) {
       plot <- hist(x, breaks = bins, col = "#75AADB", border = "white",
                    xlab = paste0("Values of ", column_name),
                    main =  paste0("This is ", dataset, ", column ", column))
+      # plot <- hist(x)
     }
     plot
   })

--- a/inst/examples/ex10-within-module/parmesan/inputs.yaml
+++ b/inst/examples/ex10-within-module/parmesan/inputs.yaml
@@ -1,0 +1,41 @@
+plot_type:
+  show: true
+  input_type: radioButtons
+  input_params:
+    label: Plot Type
+    choices:
+      - Plot
+      - Histogram
+bins:
+  show: true
+  show_if: 
+    plot_type:
+      equals: Histogram
+  input_type: sliderInput
+  input_params:
+    label: Bins
+    min: 0
+    max: 50
+    value: 10
+    step: 1
+  update_param: value
+dataset:
+  show: true
+  input_type: selectInput
+  input_params:
+    label: Dataset
+    choices:
+      - rock
+      - pressure
+      - cars
+    selected: rock
+  update_param: selected
+column:
+  show: true
+  input_type: numericInput
+  input_params:
+    label: datasetNColsLabel()
+    min: 1
+    max: datasetNCols()
+    value: 1
+  update_param: value

--- a/inst/examples/ex10-within-module/parmesan/layout.yaml
+++ b/inst/examples/ex10-within-module/parmesan/layout.yaml
@@ -1,0 +1,13 @@
+controls:
+  label: Controls
+  inputs:
+    - dataset
+    - plot_type
+    - bins
+controls_dark:
+  label: Controls Dark
+  inputs:
+    - column
+controls_empty:
+  label: Controls Empty
+  inputs:


### PR DESCRIPTION
With this PR, `output_parmesan` works from within a shiny module.

When used normally (not within a module) nothing has to be changed.

When used within a module, see added example `ex10-within-module`. In summary, it works as follows:

A parameter `r = reactiveValues` has to be passed from the main server function to the module that contains `output_parmesan`. 

```
server <-  function(input, output, session) {

  r <- reactiveValues()

  parmesanServer("parmesan_module", r = r)

... }
```

This also has to be passed to `output_parmesan`, and all inputs and reactives that parmesan depends on need to be assigned to the `r`

```
parmesanServer <- function(id, r) {
  moduleServer(
    id,
    function(input, output, session) {

observe({
        r$dataset<- dataset
      })

output_parmesan("controls", r = r, parmesan = parmesan,
                             input = input, output = output, session = session,
                             container_section = div_dark)
...}
```