### PR TITLE
Add warning messages for eval_reactive

### DIFF
--- a/R/output.R
+++ b/R/output.R
@@ -145,12 +145,7 @@ output_parmesan <- function(id,
         if(input_has_reactive_tooltip_text(par_input)){
 
           text <-  par_input$input_info$text
-          if(is.null(r)){
-            text <- do.call(remove_parenthesis(text), list(), envir = env)
-          } else {
-            text <- do.call(r[[remove_parenthesis(text)]], list())
-          }
-          par_input$input_info$text <- text
+          par_input$input_info$text <- evaluate_reactive(x = text, env = env, r = r)
 
           last_input <- section$inputs[[x-1]]
           last_input_id <- paste0("output_", last_input$id)

--- a/R/render_par_input_helpers.R
+++ b/R/render_par_input_helpers.R
@@ -27,18 +27,29 @@ is_reactive_string <- function(x){
 
 evaluate_reactive <- function(x, env, r = NULL){
   if(is.null(r)){
-    do.call(remove_parenthesis(x), list(), envir = env)
+    value <- do.call(remove_parenthesis(x), list(), envir = env)
   } else {
-    do.call(r[[remove_parenthesis(x)]], list())
+    value <- tryCatch({
+      do.call(r[[remove_parenthesis(x)]], list())},
+      error=function(cond) {
+        if(is.null(r[[x]]) & nchar(cond) > 0){
+          message(paste0("Can't find ", x, " in reactiveValues within r."))
+          message("Error message:")
+          message(cond)
+        }
+        return(NULL)
+      })
   }
+  value
 }
 
 evaluate_input <- function(x, r = NULL){
   if(is.null(r)){
-    input[[x]]
+    value <- input[[x]]
   } else {
-    r[[x]]
+    value <- r[[x]]
   }
+  value
 }
 
 is_shiny_input <- function(x, input, r = NULL){


### PR DESCRIPTION
`output_parmesan` is raising uninformative errors when used in a different app. Adding informative messages to `eval_reactive` for easier debugging.